### PR TITLE
Use new `createTheme` RSF util instead of MUI's version

### DIFF
--- a/components/theme.js
+++ b/components/theme.js
@@ -1,8 +1,8 @@
-import { createMuiTheme } from '@material-ui/core/styles'
+import createTheme from 'react-storefront/utils/createTheme'
 import { red } from '@material-ui/core/colors'
 
 // Create a theme instance.
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',
@@ -16,18 +16,6 @@ const theme = createMuiTheme({
     background: {
       default: '#fff',
     },
-  },
-  zIndex: {
-    modal: 999,
-    amp: {
-      modal: 2147483646,
-    },
-  },
-  headerHeight: 64,
-  loadMaskOffsetTop: 64 + 56 + 4,
-  drawerWidth: 330,
-  margins: {
-    container: 16,
   },
   overrides: {},
 })

--- a/components/theme.js
+++ b/components/theme.js
@@ -1,4 +1,4 @@
-import createTheme from 'react-storefront/utils/createTheme'
+import createTheme from 'react-storefront/theme/createTheme'
 import { red } from '@material-ui/core/colors'
 
 // Create a theme instance.


### PR DESCRIPTION
In conjunction with [PR #26](https://github.com/react-storefront-community/react-storefront/pull/26) in RSF, this implements the new `createTheme` util.