### PR TITLE
Add deployment scripts for create-react-storefront apps

### DIFF
--- a/crs-resources/.github/workflows/xdn-deploy.yml
+++ b/crs-resources/.github/workflows/xdn-deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy branch to XDN
+
+on:
+  push:
+  release:
+    types: [published]
+
+jobs:
+  deploy-to-xdn:
+    # cancels the deployment for the automatic merge push created when tagging a release
+    if: contains(github.ref, 'refs/tags') == false || github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for XDN deploy token secret
+        if: env.xdn_deploy_token == ''
+        run: |
+          echo You must define the "xdn_deploy_token" secret in GitHub project settings
+          exit 1
+        env:
+          xdn_deploy_token: ${{secrets.xdn_deploy_token}}
+      - name: Extract branch name
+        shell: bash
+        run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')"
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://npm-proxy.fury.io/moovweb/
+      - name: Cache node modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - run: npm ci
+      - name: Deploy to XDN
+        run: npm run deploy -- ${{'--branch=$BRANCH_NAME' || ''}} --token=$xdn_deploy_token ${{github.event_name == 'push' && env.BRANCH_NAME == 'master' && '--environment=staging' || ''}} ${{github.event_name == 'release' && '--environment=production' || ''}}
+        env:
+          xdn_deploy_token: ${{secrets.xdn_deploy_token}}


### PR DESCRIPTION
Adds a resource directory to be copied into the root directory when running `create-react-storefront`. The file added here will be copied into the github workflows to publish to the XDN as such:
- Deploy to environment=production on publish release
- Deploy to environment=staging on push to master
- Deploy without an environment on all other branch pushes

Related to create-react-storefront [PR #4](https://github.com/react-storefront-community/create-react-storefront/pull/4).